### PR TITLE
Add Python code coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,5 +40,11 @@ jobs:
           pip install -e .
           pip install -r requirements.txt
           python examples/demo.py
-          python -m pytest
+      
+      # Runs unit tests and coverage report. For now, set coverage to
+      # fail if it's less than 25 percent. We will adjust this number higher
+      # as we continue developing.
+      - name: Run unit tests and coverage report
+          python -m pytest --cov=./ --cov-fail-under=25
+
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,8 @@ jobs:
       # fail if it's less than 25 percent. We will adjust this number higher
       # as we continue developing.
       - name: Run unit tests and coverage report
-          python -m pytest --cov=./ --cov-fail-under=25
+        run: |
+          python -m pytest --cov=agents/ --cov=gym_xiangqi/ \
+            --cov=examples/ --cov-report=html --cov-fail-under=25
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,6 @@ jobs:
       # as we continue developing.
       - name: Run unit tests and coverage report
         run: |
-          python -m pytest --cov=agents/ --cov=gym_xiangqi/ \
-            --cov=examples/ --cov-report=html --cov-fail-under=25
+          python -m pytest --cov=agents/ --cov=gym_xiangqi/ --cov=examples/ --cov-fail-under=25
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ __pycache__
 
 # Distribution / packaging
 *.egg-info/
+
+# Testing
+.coverage
+htmlcov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest==6.2.2
 pytest-mock==3.5.1
+pytest-cov==2.11.1


### PR DESCRIPTION
# Description

This PR adds Python code coverage to CI, and it's set to fail if the coverage is below 25%. This number should only increase from this point on.

This check is also put under CI/build check since building and installing dependencies are required before pytest can work. To check the coverage, look under checks section, CI/<any build>/Run unit tests and coverage report.

# Type of change

- [] Bug fix (non-breaking changes which fixes an issue)
- [X] New feature (non-breaking changes which adds certain functionality)
- [] Documentation update (updating documentations)
- [] Breaking change (fix that breaks existing functionality)

# How has this been tested?

CI