### PR TITLE
Add Radon Analysis to CI

### DIFF
--- a/.github/workflows/radon.yml
+++ b/.github/workflows/radon.yml
@@ -1,0 +1,26 @@
+name: Radon Analysis
+
+on: [pull_request]
+
+jobs:
+  radon-analysis:
+    runs-one: ubuntu-latest
+    name: radon-analysis
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v2
+      - name: Set up Python environment
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: pip install requirements.txt
+      - name: Cyclomatic Complexity
+        run: radon cc ./
+      - name: Maintainability Index
+        run: radon mi ./
+      - name: Code Lines Analysis
+        run: radon raw ./ --summary
+      - name: Halstead Complexity
+        run: radon hal ./
+

--- a/.github/workflows/radon.yml
+++ b/.github/workflows/radon.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           python-version: "3.8"
       - name: Install dependencies
-        run: pip install requirements.txt
+        run: pip install -r requirements.txt
       - name: Cyclomatic Complexity
         run: radon cc ./
       - name: Maintainability Index

--- a/.github/workflows/radon.yml
+++ b/.github/workflows/radon.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   radon-analysis:
-    runs-one: ubuntu-latest
+    runs-on: ubuntu-latest
     name: radon-analysis
     steps:
       - name: Check out source repository

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest==6.2.2
 pytest-mock==3.5.1
 pytest-cov==2.11.1
+radon==4.3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,4 +31,4 @@ show_complexity = true
 show_mi = true
 # Raw Analysis
 # Halstead Complexity
-function = true
+functions = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,9 +14,21 @@ classifiers =
 
 [options]
 packages = find:
-# TODO: Currently does not matter but double check later
+# TODO: Currently does not matter but double check later.
 python_requires = >=3.6
 install_requires =
     gym
     wheel
     pygame
+
+# Config for radon analysis.
+[radon]
+exclude = *_test.py
+# Cyclomatic Complexity
+total_average = true
+show_complexity = true
+# Maintainability Index
+show_mi = true
+# Raw Analysis
+# Halstead Complexity
+function = true


### PR DESCRIPTION
# Description

This PR adds [radon](https://pypi.org/project/radon/) analysis, which includes cyclomatic complexity, raw metrics like code lines, comment lines, etc, halstead complexity, and maintainability index into the CI. These analysis will not fail for now, as there's no clear threshold that I can set for it to fail. In the future, we can gauge the right threshold to set and make it fail CI if it exceed certain criterias.

# Type of change

- [] Bug fix (non-breaking changes which fixes an issue)
- [X] New feature (non-breaking changes which adds certain functionality)
- [] Documentation update (updating documentations)
- [] Breaking change (fix that breaks existing functionality)

# How has this been tested?

CI
