### PR TITLE
Add latency report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@
 
 name: CI
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
@@ -40,10 +40,14 @@ jobs:
           pip install -e .
           pip install -r requirements.txt
           python examples/demo.py
-      
+
       # Runs unit tests and coverage report. For now, set coverage to
       # fail if it's less than 25 percent. We will adjust this number higher
       # as we continue developing.
       - name: Run unit tests and coverage report
         run: |
           python -m pytest --cov=agents/ --cov=gym_xiangqi/ --cov=examples/ --cov-fail-under=25
+
+      # Run latency test to get latency report.
+      - name: Run latency test
+        run: python test/latency_test.py

--- a/test/latency_test.py
+++ b/test/latency_test.py
@@ -2,22 +2,28 @@ from gym_xiangqi.envs.xiangqi_env import XiangQiEnv  # NOQA
 from agents.random_agent import RandomAgent  # NOQA
 import timeit
 
-NUM_REPEAT = 5
+""" Timing """
+# Number of times to repeat the timing tests.
+NUM_REPEAT = 10
+# Number of times to call a method for each timing test.
 NUM_RUN = 1
+
+""" Setup """
 ENV_SETUP = "env = XiangQiEnv()"
 AGENT_SETUP = "agent = RandomAgent()"
 
 
-def average(lst):
-    return sum(lst) / len(lst)
-
-
 def print_time(title, time_list):
+    """
+    Helper function to print latency times
+    in a nice format.
+    """
+    assert len(time_list) == NUM_REPEAT
     print(f"{title}")
     print("--------------------")
     print(f"min    : {min(time_list):.3f}")
     print(f"max    : {max(time_list):.3f}")
-    print(f"average: {average(time_list):.3f}")
+    print(f"average: {sum(time_list) / len(time_list):.3f}")
     print("\n")
 
 
@@ -46,6 +52,10 @@ def measure_and_print_latency(methods_to_setup):
 
 
 def env_latency():
+    """
+    Measure and print the latency of the methods defined
+    in XiangQiEnv.
+    """
     print("XiangQiEnv Latency (ms)")
     print("=========================")
 
@@ -62,6 +72,10 @@ def env_latency():
 
 
 def random_agent_latency():
+    """
+    Measure and print the latency of the methods defined
+    in RandomAgent.
+    """
     print("RandomAgent Latency (ms)")
     print("=========================")
 

--- a/test/latency_test.py
+++ b/test/latency_test.py
@@ -87,5 +87,8 @@ def random_agent_latency():
 
 
 if __name__ == "__main__":
+    # TODO: Compare latency from before and after a PR, and actually
+    # fail a PR if the change if too big or if the latency
+    # exceed a certain number.
     env_latency()
     random_agent_latency()

--- a/test/latency_test.py
+++ b/test/latency_test.py
@@ -46,7 +46,7 @@ def measure_and_print_latency(methods_to_setup):
 
 
 def env_latency():
-    print(f"XiangQiEnv Latency (ms)")
+    print("XiangQiEnv Latency (ms)")
     print("=========================")
 
     methods_to_setup = {
@@ -55,14 +55,14 @@ def env_latency():
         "env.get_possible_actions()": ENV_SETUP,
         "env.step(action)":
             f"{ENV_SETUP}; import numpy as np; import random;"
-             "actions = np.where(env.possible_actions == 1)[0];"
-             "action = random.randint(0, len(actions)-1);"
+            "actions = np.where(env.possible_actions == 1)[0];"
+            "action = random.randint(0, len(actions)-1);"
     }
     measure_and_print_latency(methods_to_setup)
 
 
 def random_agent_latency():
-    print(f"RandomAgent Latency (ms)")
+    print("RandomAgent Latency (ms)")
     print("=========================")
 
     methods_to_setup = {
@@ -75,4 +75,3 @@ def random_agent_latency():
 if __name__ == "__main__":
     env_latency()
     random_agent_latency()
-

--- a/test/latency_test.py
+++ b/test/latency_test.py
@@ -1,5 +1,5 @@
-from gym_xiangqi.envs.xiangqi_env import XiangQiEnv
-from agents.random_agent import RandomAgent
+from gym_xiangqi.envs.xiangqi_env import XiangQiEnv  # NOQA
+from agents.random_agent import RandomAgent  # NOQA
 import timeit
 
 NUM_REPEAT = 5
@@ -31,7 +31,15 @@ def measure_time(cmd_str, setup=""):
         repeat=NUM_REPEAT, number=NUM_RUN))
 
 
-def print_latency(methods_to_setup):
+def measure_and_print_latency(methods_to_setup):
+    """
+    Helper function to measure and print the latency
+    of methods specified in methods_to_setup.
+
+    Parameters:
+        methods_to_setup (dict[str, str]): Dictionary matching method calls
+            to setups needed to perform the call.
+    """
     for method, setup in methods_to_setup.items():
         time_list = measure_time(cmd_str=method, setup=setup)
         print_time(title=method, time_list=time_list)
@@ -47,11 +55,11 @@ def env_latency():
         "env.get_possible_actions()": ENV_SETUP,
         "env.step(action)":
             f"{ENV_SETUP}; import numpy as np; import random;"
-            f"actions = np.where(env.possible_actions == 1)[0];"
-            f"action = random.randint(0, len(actions)-1);"
+             "actions = np.where(env.possible_actions == 1)[0];"
+             "action = random.randint(0, len(actions)-1);"
     }
+    measure_and_print_latency(methods_to_setup)
 
-    print_latency(methods_to_setup)
 
 def random_agent_latency():
     print(f"RandomAgent Latency (ms)")
@@ -61,10 +69,10 @@ def random_agent_latency():
         "RandomAgent()": "",
         "agent.move(env)": f"{ENV_SETUP}; {AGENT_SETUP}",
     }
-
-    print_latency(methods_to_setup)
+    measure_and_print_latency(methods_to_setup)
 
 
 if __name__ == "__main__":
     env_latency()
     random_agent_latency()
+

--- a/test/latency_test.py
+++ b/test/latency_test.py
@@ -1,0 +1,70 @@
+from gym_xiangqi.envs.xiangqi_env import XiangQiEnv
+from agents.random_agent import RandomAgent
+import timeit
+
+NUM_REPEAT = 5
+NUM_RUN = 1
+ENV_SETUP = "env = XiangQiEnv()"
+AGENT_SETUP = "agent = RandomAgent()"
+
+
+def average(lst):
+    return sum(lst) / len(lst)
+
+
+def print_time(title, time_list):
+    print(f"{title}")
+    print("--------------------")
+    print(f"min    : {min(time_list):.3f}")
+    print(f"max    : {max(time_list):.3f}")
+    print(f"average: {average(time_list):.3f}")
+    print("\n")
+
+
+def s_to_ms(time_list):
+    return [t * 1000 for t in time_list]
+
+
+def measure_time(cmd_str, setup=""):
+    return s_to_ms(timeit.repeat(
+        cmd_str, setup=setup, globals=globals(),
+        repeat=NUM_REPEAT, number=NUM_RUN))
+
+
+def print_latency(methods_to_setup):
+    for method, setup in methods_to_setup.items():
+        time_list = measure_time(cmd_str=method, setup=setup)
+        print_time(title=method, time_list=time_list)
+
+
+def env_latency():
+    print(f"XiangQiEnv Latency (ms)")
+    print("=========================")
+
+    methods_to_setup = {
+        "XiangQiEnv()": "",
+        "env.init_pieces()": ENV_SETUP,
+        "env.get_possible_actions()": ENV_SETUP,
+        "env.step(action)":
+            f"{ENV_SETUP}; import numpy as np; import random;"
+            f"actions = np.where(env.possible_actions == 1)[0];"
+            f"action = random.randint(0, len(actions)-1);"
+    }
+
+    print_latency(methods_to_setup)
+
+def random_agent_latency():
+    print(f"RandomAgent Latency (ms)")
+    print("=========================")
+
+    methods_to_setup = {
+        "RandomAgent()": "",
+        "agent.move(env)": f"{ENV_SETUP}; {AGENT_SETUP}",
+    }
+
+    print_latency(methods_to_setup)
+
+
+if __name__ == "__main__":
+    env_latency()
+    random_agent_latency()


### PR DESCRIPTION
# Description

This PR adds a script which measures the latency of the methods in env and agent using [timeit](https://docs.python.org/3/library/timeit.html). This script will also run as part of the CI with all 3 different OSs (Windows, Mac and Ubuntu).

For now, the latency test will not flag or fail any PR. Future work includes comparing latency from before and after a PR, and failing if the change is large or if the change exceed a certain amount of latency.

Example of latency report output from CI can be found [here](https://github.com/tanliyon/gym-xiangqi/pull/21/checks?check_run_id=2028399464) under the `Run latency test` section.

This is how it looks like:
![latency report](https://user-images.githubusercontent.com/35442777/109917438-52ea1580-7cf0-11eb-8162-431edb19173c.JPG)

# Type of change

- [] Bug fix (non-breaking changes which fixes an issue)
- [X] New feature (non-breaking changes which adds certain functionality)
- [] Documentation update (updating documentations)
- [] Breaking change (fix that breaks existing functionality)

# How has this been tested?

`python test/latency_test.py` and CI