### PR TITLE
Implement environment reset method

### DIFF
--- a/gym_xiangqi/envs/xiangqi_env.py
+++ b/gym_xiangqi/envs/xiangqi_env.py
@@ -95,10 +95,8 @@ class XiangQiEnv(gym.Env):
         self.agent_color = agent_color
         if agent_color == RED:
             self.enemy_color = BLACK
-            self.turn = AGENT
         else:
             self.enemy_color = RED
-            self.turn = ENEMY
 
         # epoch termination flag
         self._done = False
@@ -118,21 +116,22 @@ class XiangQiEnv(gym.Env):
         self.action_space = spaces.Discrete(n)
 
         # initial board state
-        self.state = np.array(self.initial_board)
+        self.state = None
 
         # instantiate piece objects
         self.agent_piece = [None for _ in range(PIECE_CNT + 1)]
         self.enemy_piece = [None for _ in range(PIECE_CNT + 1)]
-        self.init_pieces()
 
         # possible moves: binary list with same shape of action space
         #                 valid action will be represented as 1 else 0
         self.agent_actions = np.zeros((n, ))
         self.enemy_actions = np.zeros((n, ))
-        self.get_possible_actions(self.turn)
 
         # initialize PyGame module
         self.game = None
+
+        # reset all environment components to initial state
+        self.reset()
 
     def step(self, action):
         """
@@ -202,7 +201,18 @@ class XiangQiEnv(gym.Env):
         return np.array(self.state), reward, self._done, {}
 
     def reset(self):
-        pass
+        """
+        Reset all environment components to initial state
+        """
+        self.state = np.array(self.initial_board)
+        self.init_pieces()
+
+        if self.agent_color == RED:
+            self.turn = AGENT
+        else:
+            self.turn = ENEMY
+
+        self.get_possible_actions(self.turn)
 
     def render(self, mode='human'):
         if self.game is None:


### PR DESCRIPTION
# Description

I have added environment `reset()` method. I kept a line that calls `self.reset()` in environment `__init__()` but most gym environment seems to separate this out. This means when the environment constructor is called, environment states and components are either randomly initialized or undefined at the moment and they specifically require users to call `reset()` method right after environment initialization. I guess this difference is no big deal and it will be an easy change if we see any problem. Let me know what you guys think!

# Type of change

- [ ] Bug fix (non-breaking changes which fixes an issue)
- [x] New feature (non-breaking changes which adds certain functionality)
- [ ] Documentation update (updating documentations)
- [ ] Breaking change (fix that breaks existing functionality)

# How has this been tested?

Tested with CI but unit test specific to `reset()` method is not written. The environment is calling `self.reset()` in `self.__init__()`, so existing tests should suffice for now. Let me know if you guys think we can add something more meaningful in terms of testing.
