### PR TITLE
Add more Xiangqi rules to env

### DIFF
--- a/gym_xiangqi/constants.py
+++ b/gym_xiangqi/constants.py
@@ -11,8 +11,6 @@ FPS = 20
 COUNT = 10
 
 """ POINTS """
-ILLEGAL_MOVE = -10
-
 PIECE_POINTS = [
     0.,                     # EMPTY: No point for empty grid
     float('inf'),           # GENERAL: Priceless for the general
@@ -23,6 +21,10 @@ PIECE_POINTS = [
     4.5, 4.5,               # CANNON: 4.5 points
     1., 1., 1., 1., 1.,     # SOLDIER: 1.0 point (2.0 after crossing river)
 ]
+
+ILLEGAL_MOVE = -10
+WIN = PIECE_POINTS[1]
+LOSE = -PIECE_POINTS[1]
 
 """ PIECE """
 AGENT = 1

--- a/gym_xiangqi/constants.py
+++ b/gym_xiangqi/constants.py
@@ -22,7 +22,8 @@ PIECE_POINTS = [
     1., 1., 1., 1., 1.,     # SOLDIER: 1.0 point (2.0 after crossing river)
 ]
 
-ILLEGAL_MOVE = -10
+ILLEGAL_MOVE = -10.
+JIANG_POINT = 10.
 WIN = PIECE_POINTS[1]
 LOSE = -PIECE_POINTS[1]
 

--- a/gym_xiangqi/envs/xiangqi_env.py
+++ b/gym_xiangqi/envs/xiangqi_env.py
@@ -170,7 +170,7 @@ class XiangQiEnv(gym.Env):
             pieces = self.enemy_piece
             possible_actions = self.enemy_actions
 
-        # if illegal move is given, penalize agent: flying general, etc.
+        # check for illegal move, flying general, etc. and penalize the agent
         if possible_actions[action] == 0:
             return np.array(self.state), ILLEGAL_MOVE, False, {}
         if self.check_flying_general(action):
@@ -326,23 +326,23 @@ class XiangQiEnv(gym.Env):
         Parameters:
             action (int): action value in the range of env's action space
         """
-        piece_id, start, end = action_space_to_move(action)
+        piece_id, (r1, c1), (r2, c2) = action_space_to_move(action)
 
         # simulate input action without altering current game state
         new_state = np.array(self.state)
-        new_state[start] = EMPTY
-        new_state[end] = piece_id * self.turn
+        new_state[r1][c1] = EMPTY
+        new_state[r2][c2] = piece_id * self.turn
 
-        enemy_general = self.enemy_piece[GENERAL]
-        agent_general = self.agent_piece[GENERAL]
+        enemy_gen = self.enemy_piece[GENERAL]
+        agent_gen = self.agent_piece[GENERAL]
 
         # check if they are in the same column
-        if enemy_general.col != agent_general.col:
+        if enemy_gen.col != agent_gen.col:
             return False
 
         # check if anything is in between the two generals
-        c = enemy_general.col
-        for r in range(BOARD_ROWS):
+        c = enemy_gen.col
+        for r in range(enemy_gen.row+1, agent_gen.row):
             if new_state[r][c] != EMPTY:
                 return False
         return True

--- a/gym_xiangqi/envs/xiangqi_env.py
+++ b/gym_xiangqi/envs/xiangqi_env.py
@@ -225,12 +225,6 @@ class XiangQiEnv(gym.Env):
         self.turn *= -1     # AGENT (1) -> ENEMY (-1) and vice versa
         self.get_possible_actions(self.turn)
 
-        # Stalemate checking
-        agent_sm = self.turn == AGENT and not np.where(self.agent_actions == 1)
-        enemy_sm = self.turn == ENEMY and not np.where(self.enemy_actions == 1)
-        if agent_sm or enemy_sm:
-            self._done = True
-
         return np.array(self.state), reward, self._done, {}
 
     def reset(self):

--- a/gym_xiangqi/envs/xiangqi_env.py
+++ b/gym_xiangqi/envs/xiangqi_env.py
@@ -12,7 +12,7 @@ from gym_xiangqi.constants import (
     BOARD_ROWS, BOARD_COLS,
     TOTAL_POS, PIECE_CNT,
     RED, BLACK, ALIVE, DEAD,
-    ILLEGAL_MOVE, PIECE_POINTS,
+    ILLEGAL_MOVE, PIECE_POINTS, LOSE,
     AGENT, ENEMY, EMPTY, GENERAL,
 )
 
@@ -128,6 +128,10 @@ class XiangQiEnv(gym.Env):
         self.agent_actions = np.zeros((n, ))
         self.enemy_actions = np.zeros((n, ))
 
+        # history of consecutive checks made ot be used to ban perpetual check
+        self.agent_jiang_history = None
+        self.enemy_jiang_history = None
+
         # initialize PyGame module
         self.game = None
 
@@ -166,9 +170,11 @@ class XiangQiEnv(gym.Env):
         if self.turn == AGENT:
             pieces = self.agent_piece
             possible_actions = self.agent_actions
+            jiang_history = self.agent_jiang_history
         else:
             pieces = self.enemy_piece
             possible_actions = self.enemy_actions
+            jiang_history = self.enemy_jiang_history
 
         # check for illegal move, flying general, etc. and penalize the agent
         if possible_actions[action] == 0:
@@ -197,6 +203,17 @@ class XiangQiEnv(gym.Env):
         if abs(rm_piece_id) == GENERAL:
             self._done = True
 
+        # check for perpetual checking
+        # check if "Jiang" is announced due to last move
+        is_jiang, jiang_action = self.check_jiang()
+        if is_jiang:
+            if jiang_action not in jiang_history:
+                jiang_history[jiang_action] = 0
+            jiang_history[jiang_action] += 1
+            if jiang_history[jiang_action] == 3:
+                self._done = True
+                return np.array(self.state), LOSE, self._done, {}
+
         # self-play: agent switches turn between agent and enemy side
         self.turn *= -1     # AGENT (1) -> ENEMY (-1) and vice versa
         self.get_possible_actions(self.turn)
@@ -215,6 +232,9 @@ class XiangQiEnv(gym.Env):
         """
         self.state = np.array(self.initial_board)
         self.init_pieces()
+
+        self.agent_jiang_history = {}
+        self.enemy_jiang_history = {}
 
         if self.agent_color == RED:
             self.turn = AGENT
@@ -346,3 +366,27 @@ class XiangQiEnv(gym.Env):
             if new_state[r][c] != EMPTY:
                 return False
         return True
+
+    def check_jiang(self):
+        """
+        Check if the general is in threat (i.e it is check or "jiang")
+        by any of current player's pieces
+        """
+        # This is OPPONENT General
+        if self.turn == AGENT:
+            general = self.enemy_piece[GENERAL]
+            actions = self.agent_actions
+        else:
+            general = self.agent_piece[GENERAL]
+            actions = self.enemy_actions
+
+        # update current player's moves
+        self.get_possible_actions(self.turn)
+
+        # iterate through possible moves of current player's pieces
+        actions = np.where(actions == 1)[0]
+        for action in actions:
+            _, _, (target_r, target_c) = action_space_to_move(action)
+            if target_r == general.row and target_c == general.col:
+                return True, action
+        return False, -1

--- a/gym_xiangqi/envs/xiangqi_env.py
+++ b/gym_xiangqi/envs/xiangqi_env.py
@@ -128,7 +128,7 @@ class XiangQiEnv(gym.Env):
         self.agent_actions = np.zeros((n, ))
         self.enemy_actions = np.zeros((n, ))
 
-        # history of consecutive checks made ot be used to ban perpetual check
+        # history of consecutive jiangs (will be used to ban perpetual check)
         self.agent_jiang_history = None
         self.enemy_jiang_history = None
 

--- a/gym_xiangqi/envs/xiangqi_env.py
+++ b/gym_xiangqi/envs/xiangqi_env.py
@@ -199,6 +199,12 @@ class XiangQiEnv(gym.Env):
         self.turn *= -1     # AGENT (1) -> ENEMY (-1) and vice versa
         self.get_possible_actions(self.turn)
 
+        # Stalemate checking
+        agent_sm = self.turn == AGENT and not np.where(self.agent_actions == 1)
+        enemy_sm = self.turn == ENEMY and not np.where(self.enemy_actions == 1)
+        if agent_sm or enemy_sm:
+            self._done = True
+
         return np.array(self.state), reward, self._done, {}
 
     def reset(self):

--- a/gym_xiangqi/test/xiangqi_env_test.py
+++ b/gym_xiangqi/test/xiangqi_env_test.py
@@ -14,6 +14,11 @@ from gym_xiangqi.constants import (
 
 class TestXiangQiEnv(unittest.TestCase):
 
+    def assertStateEqual(self, obs, new_obs):
+        for i in range(BOARD_ROWS):
+            for j in range(BOARD_COLS):
+                self.assertEqual(obs[i][j], new_obs[i][j])
+
     def setUp(self):
         self.env = XiangQiEnv()
 
@@ -53,6 +58,23 @@ class TestXiangQiEnv(unittest.TestCase):
             action = "".join(random.choice(choices) for i in range(length))
             self.env.step(action)
 
+    def test_flying_general(self):
+        """
+        Verification of flying general condition checker
+        Given an action that results in flying general, the environment has
+        to reject and penalize the agent
+        """
+        # pre-defined actions tht will result in a flying general situation
+        actions = [78727, 75172, 78961, 74938, 75720, 78177]
+
+        for action in actions:
+            obs = self.env.state
+            new_obs, reward, _, _ = self.env.step(action)
+
+        # check that our state is preserved and the reward is a penalty
+        self.assertStateEqual(obs, new_obs)
+        self.assertEqual(reward, ILLEGAL_MOVE)
+
     def test_env_step_illegal_move(self):
         """
         verify agent with illegal move
@@ -60,9 +82,7 @@ class TestXiangQiEnv(unittest.TestCase):
         obs = self.env.state
         new_obs, reward, done, info = self.env.step(0)
 
-        for i in range(BOARD_ROWS):
-            for j in range(BOARD_COLS):
-                self.assertEqual(obs[i][j], new_obs[i][j])
+        self.assertStateEqual(obs, new_obs)
         self.assertEqual(reward, ILLEGAL_MOVE)
         self.assertEqual(done, False)
 


### PR DESCRIPTION
# Description

Mainly added more game rules:
1. Flying General
   - Any move that result in flying general is rejected by the environment and consequently the agent is penalized for making such illegal move.
2. Perpetual Check
    - An agent cannot make the same check or "jiang" consecutively for more than THREE times. After making more than three the same type of check (i.e. at 4th iteration of such move), the player loses for violating this rule.
3. Jiang Reward
   - Awards the player for making jiang moves (though the environment does not warn the player under jiang)
   - You will notice that I have changed one of the existing test, `test_env_step_reward`. This is because I added jiang reward. I had to modify the moves so that they are only capturing without making jiang.

- I have NOT added stalemate checking because this feels like something that the agent would learn as it gets smarter. 
For example, let's say an agent manages to stalemate the opponent but is not smart enough to capture the opponent general on its next move and instead breaks the stalemate. I feel like the agent should be more responsible, but at the same time I am not sure if it is the job of the environment to check for such things for the agents. 
Since we did not include features like condition checking and informing for checks ("jiangs") and termination of episode when no meaningful progress is made by the agent,  I think we can leave out stalemate checking for now. Let me know what you guys think. I can always add it if we have good reasons to do so.

# Type of change

- [ ] Bug fix (non-breaking changes which fixes an issue)
- [x] New feature (non-breaking changes which adds certain functionality)
- [ ] Documentation update (updating documentations)
- [ ] Breaking change (fix that breaks existing functionality)

# How has this been tested?

CI (I added some basic unit tests for these new changes)
