### PR TITLE
add bgm toggling

### DIFF
--- a/gym_xiangqi/xiangqi_game.py
+++ b/gym_xiangqi/xiangqi_game.py
@@ -39,6 +39,7 @@ class XiangQiGame:
         self.end_pos = None
         self.next_moves = None
         self.cur_sel_basic_img = None
+        self.bgm_switch = True
 
     def on_init(self, agent_piece, enemy_piece):
         """
@@ -118,6 +119,29 @@ class XiangQiGame:
             # print(pygame_x, pygame_y)
             self.screen.blit(self.cur_sel_basic_img, (pygame_y, pygame_x))
 
+    def toggle_bgm(self):
+        if self.bgm_switch:
+            pygame.mixer.music.play(-1)
+        else:
+            pygame.mixer.music.stop()
+
+    def update_bgm_state(self):
+        """
+        show whether the bgm is on or off
+        """
+        bgm_font = pygame.font.SysFont(None, 25)
+        bgm_text = "BGM(v): "
+        if self.bgm_switch:
+            bgm_text += "ON"
+            final_text = bgm_font.render(bgm_text, True, (200, 100, 100))
+            text_rect = final_text.get_rect(centerx=650, bottom=550)
+            self.screen.blit(final_text, text_rect)
+        else:
+            bgm_text += "OFF"
+            final_text = bgm_font.render(bgm_text, True, (100, 100, 200))
+            text_rect = final_text.get_rect(centerx=650, bottom=550)
+            self.screen.blit(final_text, text_rect)
+
     def on_event(self, event):
         """
         This routine is triggered when some kind of user/game event is detected
@@ -126,6 +150,11 @@ class XiangQiGame:
         """
         if event.type == pygame.QUIT:
             self.running = False
+
+        elif event.type == pygame.KEYUP:
+            if event.key == pygame.K_v:
+                self.bgm_switch = not self.bgm_switch
+                self.toggle_bgm()
 
         elif event.type == pygame.MOUSEBUTTONDOWN:
             # clicked: 1 not_clicked: 0
@@ -185,6 +214,7 @@ class XiangQiGame:
         self.screen.fill((250, 250, 250))
         self.update_timer()
         self.update_kills()
+        self.update_bgm_state()
         self.screen.blit(self.board_background, (0, 0))
 
         # update all cur positions of pieces
@@ -293,24 +323,24 @@ class XiangQiGame:
         """
         update the remaining time and blit
         """
-        timer_text = "timer: " + str(self.counter)
-        final_text = self.font.render(timer_text, True, (128, 128, 0))
-        text_rect = final_text.get_rect(centerx=665, bottom=50)
+        timer_text = "timer:  " + str(self.counter)
+        final_text = self.font.render(timer_text, True, (0, 0, 0))
+        text_rect = final_text.get_rect(centerx=650, bottom=50)
         self.screen.blit(final_text, text_rect)
 
     def init_kills(self):
         """
         write 'agent kills: ' and 'enemy kills: ' on screen
         """
-        self.kill_font = pygame.font.SysFont(None, 40)
+        kill_font = pygame.font.SysFont(None, 40)
 
         kill_text = "agent kills: "
-        final_text = self.kill_font.render(kill_text, True, (128, 128, 0))
+        final_text = kill_font.render(kill_text, True, (20, 0, 0))
         text_rect = final_text.get_rect(centerx=610, bottom=350)
         self.screen.blit(final_text, text_rect)
 
         kill_text = "enemy kills: "
-        final_text = self.kill_font.render(kill_text, True, (128, 128, 0))
+        final_text = kill_font.render(kill_text, True, (20, 20, 20))
         text_rect = final_text.get_rect(centerx=610, bottom=150)
         self.screen.blit(final_text, text_rect)
 

--- a/gym_xiangqi/xiangqi_game.py
+++ b/gym_xiangqi/xiangqi_game.py
@@ -129,11 +129,11 @@ class XiangQiGame:
         """
         show whether the bgm is on or off
         """
-        bgm_font = pygame.font.SysFont(None, 25)
+        bgm_font = pygame.font.SysFont('bradleyhand', 20)
         bgm_text = "BGM(v): "
         if self.bgm_switch:
             bgm_text += "ON"
-            final_text = bgm_font.render(bgm_text, True, (200, 100, 100))
+            final_text = bgm_font.render(bgm_text, True, (230, 100, 100))
             text_rect = final_text.get_rect(centerx=650, bottom=550)
             self.screen.blit(final_text, text_rect)
         else:
@@ -315,7 +315,7 @@ class XiangQiGame:
         """
         initialize the timer
         """
-        self.font = pygame.font.SysFont(None, 40)
+        self.time_font = pygame.font.SysFont('cochin', 30)
         self.timer_event = pygame.USEREVENT + 1
         pygame.time.set_timer(self.timer_event, 1000)
 
@@ -324,7 +324,7 @@ class XiangQiGame:
         update the remaining time and blit
         """
         timer_text = "timer:  " + str(self.counter)
-        final_text = self.font.render(timer_text, True, (0, 0, 0))
+        final_text = self.time_font.render(timer_text, True, (0, 0, 0))
         text_rect = final_text.get_rect(centerx=650, bottom=50)
         self.screen.blit(final_text, text_rect)
 
@@ -332,16 +332,16 @@ class XiangQiGame:
         """
         write 'agent kills: ' and 'enemy kills: ' on screen
         """
-        kill_font = pygame.font.SysFont(None, 40)
+        kill_font = pygame.font.SysFont('cochin', 30)
 
-        kill_text = "agent kills: "
+        kill_text = "Agent kills: "
         final_text = kill_font.render(kill_text, True, (20, 0, 0))
-        text_rect = final_text.get_rect(centerx=610, bottom=350)
+        text_rect = final_text.get_rect(centerx=600, bottom=350)
         self.screen.blit(final_text, text_rect)
 
-        kill_text = "enemy kills: "
+        kill_text = "Enemy kills: "
         final_text = kill_font.render(kill_text, True, (20, 20, 20))
-        text_rect = final_text.get_rect(centerx=610, bottom=150)
+        text_rect = final_text.get_rect(centerx=605, bottom=150)
         self.screen.blit(final_text, text_rect)
 
     def update_kills(self):
@@ -414,7 +414,7 @@ class XiangQiGame:
         write the "game over" message on screen and wait for 3 seconds
         """
         game_over = "GAME OVER"
-        font = pygame.font.SysFont(None, 100)
+        font = pygame.font.SysFont('impact', 100)
         game_over_text = font.render(game_over, True, (128, 250, 128))
         t_rect = game_over_text.get_rect(center=self.screen.get_rect().center)
         self.screen.blit(game_over_text, t_rect)


### PR DESCRIPTION
# Description
- pygame BGM now can be toggled by pressing the 'v' key (BGM is on by default)
1.  Only supported in player vs. agent mode since agent vs. agent mode does not consistently take the user input.
2. Press button for this can be changed in the future if necessary.

- some minor changes in the font colors

# Type of change
- [] Bug fix (non-breaking changes which fixes an issue)
- [o] New feature (non-breaking changes which adds certain functionality)
- [] Documentation update (updating documentations)
- [] Breaking change (fix that breaks existing functionality)

# How has this been tested?
- locally tested under player vs. agent mode
- Travis CI