### PR TITLE
Add game state hash check

### DIFF
--- a/gym_xiangqi/envs/xiangqi_env.py
+++ b/gym_xiangqi/envs/xiangqi_env.py
@@ -112,6 +112,7 @@ class XiangQiEnv(gym.Env):
 
         # initial board state
         self._state = None
+        self._state_hash = None
 
         # instantiate piece objects
         self._ally_piece = [None for _ in range(PIECE_CNT + 1)]
@@ -153,6 +154,10 @@ class XiangQiEnv(gym.Env):
         # Validate action input
         error_msg = "%r (%s) invalid action" % (action, type(action))
         assert self.action_space.contains(action), error_msg
+
+        # Validate that the environment wasn't changed between steps
+        assert hash(str(self._state)) == self._state_hash, \
+            "Error! Game state changed illegally!"
 
         # Warn the user for calling step() when current game has finished
         if self._done:
@@ -232,6 +237,9 @@ class XiangQiEnv(gym.Env):
         self._turn *= -1     # ALLY (1) to ENEMY (-1) and vice versa
         self.get_possible_actions(self._turn)
 
+        # Update state hash.
+        self._state_hash = hash(str(self._state))
+
         return np.array(self._state), reward, self._done, {}
 
     def reset(self):
@@ -251,6 +259,7 @@ class XiangQiEnv(gym.Env):
 
         self.get_possible_actions(self._turn)
         self._game.on_init_pieces(self._ally_piece, self._enemy_piece)
+        self._state_hash = hash(str(self._state))
 
     def render(self, mode='human'):
         """

--- a/gym_xiangqi/examples/game_mode.py
+++ b/gym_xiangqi/examples/game_mode.py
@@ -26,7 +26,6 @@ def main():
             player = "You"
             piece, start, end = env.user_move_info
             piece = PIECE_ID_TO_NAME[piece]
-            end = env.game.end_pos
         else:
             time.sleep(1)
             action = agent.move(env)

--- a/gym_xiangqi/test/xiangqi_env_test.py
+++ b/gym_xiangqi/test/xiangqi_env_test.py
@@ -171,6 +171,11 @@ class TestXiangQiEnv(unittest.TestCase):
         self.assertIsInstance(seed_list, list)
         self.assertIsInstance(seed_list[0], int)
 
+    def test_env_state_hash_check(self):
+        self.env._state = None
+        with self.assertRaises(AssertionError):
+            self.env.step(300)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/gym_xiangqi/test/xiangqi_env_test.py
+++ b/gym_xiangqi/test/xiangqi_env_test.py
@@ -172,7 +172,8 @@ class TestXiangQiEnv(unittest.TestCase):
         self.assertIsInstance(seed_list[0], int)
 
     def test_env_state_hash_check(self):
-        self.env._state = None
+        self.env._state[0][7], self.env._state[2][1] = (
+            self.env._state[2][1], self.env._state[0][7])
         with self.assertRaises(AssertionError):
             self.env.step(300)
 


### PR DESCRIPTION
# Description

This PR does 2 things:

1. Adds a game state check before the `step` method to ensure that game state is not changed externally in between each call to `step`.

2. Fix a bug in `game_mode.py` where `end` when user moves prints None instead of the destination tile.

# Type of change

- [X] Bug fix (non-breaking changes which fixes an issue)
- [X] New feature (non-breaking changes which adds certain functionality)
- [] Documentation update (updating documentations)
- [] Breaking change (fix that breaks existing functionality)

# How has this been tested?

`python -m pytest`
