### PR TITLE
Fix trigger condition of publish workflow

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -3,11 +3,12 @@ name: Publish Gym Xiangqi distribution 📦 to PyPI
 on: 
   push:
     branches: [ main ]
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build-and-publish:
     name: Build and publish Gym Xiangqi distribution 📦 to PyPI
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
# Description

This is another change related to GitHub Actions publishing workflow. Apparently, the current condition is not behaving as desired. I made some changes here but may have to experiment a little if until I get the desired behavior. The following changes were added:

- Trigger condition for `publishing.yml` has been updated to detect tag pushes on `main`

Also currently we have one caveat to this feature. The version number is hard coded in `setup.cfg` and we have to manually update the version number every time we want to publish a new version. This will be very annoying. 

There is a way to automate the update by using `setuptools_scm` library, but they currently do not support SemVer. 

A good news is that they have stated in their repository's readme that they will be updating their library to support SemVer by default. We won't know when this will happen but for now let's manually update the versions and fix this problem once we have the tools available.

# Type of change

- [x] Bug fix (non-breaking changes which fixes an issue)
- [ ] New feature (non-breaking changes which adds certain functionality)
- [ ] Documentation update (updating documentations)
- [ ] Breaking change (fix that breaks existing functionality)

# How has this been tested?

CI using GitHub Actions
