### PR TITLE
Fix license info in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ url = https://github.com/tanliyon/gym-xiangqi
 license_files = LICENSE
 classifiers =
     Programming Language :: Python :: 3
-    License :: OSI Approved :: LGPLv3
+    License :: OSI Approved :: GNU LESSER GENERAL PUBLIC LICENSE V3 (LGPLV3)
     Operating System :: OS Independent
 
 [options]


### PR DESCRIPTION
# Description

- Fix unrecognized license name in `setup.cfg`

# Type of change

- [x] Bug fix (non-breaking changes which fixes an issue)
- [ ] New feature (non-breaking changes which adds certain functionality)
- [x] Documentation update (updating documentations)
- [ ] Breaking change (fix that breaks existing functionality)

# How has this been tested?

GitHub Actions
