### PR TITLE
Change publishing workflow verification step

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -57,4 +57,4 @@ jobs:
         pip install gym-xiangqi
     
     - name: Verify successful installation 🙌
-      run: agent-v-agent
+      run: python -c "import gym_xiangqi"


### PR DESCRIPTION
# Description

Previously, the publishing workflow's verification step ran the entry point `agent-v-agent`. However, in this case, the entry point program may undesirably run for a long time or not finish in time for GitHub Actions checks because of the random agent's unpredictable moves.

This change modifies GitHub Actions publishing workflow verification step to avoid this problem:
- Verify `pip install gym-xiangqi` with `python -c "import gym_xiangqi"`

# Type of change

- [x] Bug fix (non-breaking changes which fixes an issue)
- [ ] New feature (non-breaking changes which adds certain functionality)
- [ ] Documentation update (updating documentations)
- [ ] Breaking change (fix that breaks existing functionality)

# How has this been tested?

GitHub Actions with `publishing.yml`
