### PR TITLE
Fix half-working environment's reset method

### DIFF
--- a/gym_xiangqi/envs/xiangqi_env.py
+++ b/gym_xiangqi/envs/xiangqi_env.py
@@ -294,6 +294,7 @@ class XiangQiEnv(gym.Env):
         """
         Reset all environment components to initial state
         """
+        self._done = False
         self._state = np.array(INITIAL_BOARD)
         self.init_pieces()
 

--- a/gym_xiangqi/envs/xiangqi_env.py
+++ b/gym_xiangqi/envs/xiangqi_env.py
@@ -293,6 +293,9 @@ class XiangQiEnv(gym.Env):
     def reset(self):
         """
         Reset all environment components to initial state
+
+        Return:
+            observation (object): the initial observation.
         """
         self._done = False
         self._state = np.array(INITIAL_BOARD)
@@ -309,6 +312,8 @@ class XiangQiEnv(gym.Env):
         self.get_possible_actions(self._turn)
         self._game.on_init_pieces(self._ally_piece, self._enemy_piece)
         self._state_hash = hash(str(self._state))
+
+        return np.array(self._state)
 
     def render(self, mode='human'):
         """

--- a/test/xiangqi_env_test.py
+++ b/test/xiangqi_env_test.py
@@ -9,6 +9,7 @@ from gym_xiangqi.constants import (
     ILLEGAL_MOVE, PIECE_POINTS, JIANG_POINT, LOSE,
     EMPTY, GENERAL, CANNON_1, HORSE_2,
     ALLY, ENEMY,
+    INITIAL_BOARD,
 )
 
 
@@ -134,6 +135,30 @@ class TestXiangQiEnv(unittest.TestCase):
         self.assertEqual(done, True)
         self.assertEqual(reward, PIECE_POINTS[GENERAL])
         self.assertEqual(self.env.enemy_piece[GENERAL].state, DEAD)
+
+    def test_env_reset(self):
+        """
+        verify environment properly resets after an episode has terminated
+
+        Performs these series of actions:
+        78727: Ally CANNON_1 (7, 1) -> (7, 4)
+        75172: Enemy CANNON_1 (2, 7) -> (2, 4)
+        78961: Ally CANNON_1 (7, 4) -> (3, 4)
+        123966: Enemy SOLDIER_5 (3, 0) -> (4, 0)
+        75694: Ally CANNON_1 (3, 4) -> (0, 4) -- takes black general
+
+        and resets the environment.
+        """
+        actions = [78727, 75172, 78961, 123966, 75694]
+        for action in actions:
+            obs, reward, done, info = self.env.step(action)
+        self.assertEqual(done, True)
+        self.assertEqual(reward, PIECE_POINTS[GENERAL])
+        self.assertEqual(self.env.enemy_piece[GENERAL].state, DEAD)
+
+        obs = self.env.reset()
+        self.assertFalse(self.env._done)
+        self.assertStateEqual(INITIAL_BOARD, obs)
 
     def test_perpetual_check(self):
         """


### PR DESCRIPTION
# Description

There is a bug in our Xiangqi environment. Currently, the `self._done` flag is not being reset in the `reset()` method.
This problem should be fixed with the change in this PR.

### Problems
- Missing `self._done` flag reset
- Missing return statement for `XiangQiEnv.reset()` (environment's initial state should be returned)

### Changes:
- Add `self._done = False` to reset
- Add return statement that returns environment initial state
- Add minimal testing for environment `reset()` method

# Type of change

- [x] Bug fix (non-breaking changes which fixes an issue)
- [ ] New feature (non-breaking changes which adds certain functionality)
- [ ] Documentation update (updating documentations)
- [ ] Breaking change (fix that breaks existing functionality)

# How has this been tested?

GitHub Actions: CI (the new test has been added to the test suite)
