### PR TITLE
Bump soldiers' points after river

### DIFF
--- a/gym_xiangqi/envs/xiangqi_env.py
+++ b/gym_xiangqi/envs/xiangqi_env.py
@@ -18,8 +18,9 @@ from gym_xiangqi.constants import (
     TOTAL_POS, PIECE_CNT,
     RED, BLACK, ALIVE, DEAD,
     ILLEGAL_MOVE, PIECE_POINTS, LOSE,
-    ALLY, ENEMY, EMPTY, GENERAL,
+    ALLY, ENEMY, EMPTY, GENERAL, SOLDIER_1, SOLDIER_5,
     MAX_PERPETUAL_JIANG,
+    RIVER_LOW, RIVER_HIGH,
 )
 
 
@@ -252,6 +253,15 @@ class XiangQiEnv(gym.Env):
 
         # Reward based on removed piece
         reward += PIECE_POINTS[abs(rm_piece_id)]
+
+        # Check if the removed piece is a soldier that has crossed the river
+        if SOLDIER_1 <= abs(rm_piece_id) <= SOLDIER_5:
+            if is_ally(rm_piece_id):
+                if self._ally_piece[rm_piece_id].row <= RIVER_LOW:
+                    reward += 1
+            else:
+                if self._enemy_piece[rm_piece_id].row >= RIVER_HIGH:
+                    reward += 1
 
         # End game if the General on either side has been attacked
         if abs(rm_piece_id) == GENERAL:

--- a/test/xiangqi_env_test.py
+++ b/test/xiangqi_env_test.py
@@ -9,7 +9,7 @@ from gym_xiangqi.constants import (
     BOARD_ROWS, BOARD_COLS,
     RED, BLACK, DEAD,
     ILLEGAL_MOVE, PIECE_POINTS, LOSE,
-    EMPTY, GENERAL, CANNON_1, HORSE_2,
+    EMPTY, GENERAL, CANNON_1, HORSE_2, SOLDIER_1, SOLDIER_5,
     ALLY, ENEMY,
     INITIAL_BOARD,
 )
@@ -121,6 +121,23 @@ class TestXiangQiEnv(unittest.TestCase):
         self.assertEqual(reward, PIECE_POINTS[HORSE_2])
         self.assertEqual(done, False)
         self.assertEqual(self.env.enemy_piece[HORSE_2].state, DEAD)
+
+    def test_env_reward_soldier_river(self):
+        """
+        Verify that soldiers are 2.0 points after crossing the river
+
+        94005: Ally SOLDIER_1 (6,0) -> (5,0)
+        92294: Enemy SOLDIER_1 (3,8) -> (4,8)
+        93186: Ally SOLDIER_1 (5,0) -> (4,0)
+        123966: Enemy SOLDIER_5 (3, 0) -> (4, 0)
+        64026: Ally CHARIOT_1 (9,0) -> (4,0)
+        """
+        actions = [94005, 92294, 93186, 123966]
+        for action in actions:
+            obs, reward, _, _ = self.env.step(action)
+        self.assertEqual(reward, PIECE_POINTS[SOLDIER_1]+1.)
+        obs, reward, _, _ = self.env.step(64026)
+        self.assertEqual(reward, PIECE_POINTS[SOLDIER_5])
 
     def test_env_step_done(self):
         """


### PR DESCRIPTION
# Description

Our description indicates that soldiers are worth 1.0 point to begin with and 2.0 points after crossing the river.
However, we forgot to actually bump their points to 2.0. 

I have added some lines of code and tests for this logic to be accounted. It's not the cleanest way to implement but does the job for now. 

# Type of change

- [x] Bug fix (non-breaking changes which fixes an issue)
- [x] New feature (non-breaking changes which adds certain functionality)
- [ ] Documentation update (updating documentations)
- [ ] Breaking change (fix that breaks existing functionality)

# How has this been tested?

GitHub Actions CI
