### PR TITLE
Change General points

### DIFF
--- a/gym_xiangqi/constants.py
+++ b/gym_xiangqi/constants.py
@@ -18,7 +18,7 @@ COUNT = 10
 """ POINTS """
 PIECE_POINTS = [
     0.,                     # EMPTY: No point for empty grid
-    float('inf'),           # GENERAL: Priceless for the general
+    100.,                   # GENERAL: Priceless for the general
     2., 2.,                 # ADVISOR: 2.0 points
     2., 2.,                 # ELEPHANT: 2.0 points
     4., 4.,                 # HORSE: 4.0 points


### PR DESCRIPTION
# Description

This PR changes the points assigned to the General. Generals used to be `float('inf')` to denote end of the game.
However, this point scheme does not work nicely with machine learning algorithms which usually involves tensors of `float32` or `float64` types. `float('inf')` is just unnecessarily huge to be properly represented. Thus, we chose to represent the points for General to something very big in relation to other pieces while being a finite number.

# Type of change

- [x] Bug fix (non-breaking changes which fixes an issue)
- [ ] New feature (non-breaking changes which adds certain functionality)
- [ ] Documentation update (updating documentations)
- [ ] Breaking change (fix that breaks existing functionality)

# How has this been tested?

GitHub Actions: CI
